### PR TITLE
Raise plugin- and/or role versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.9.x'
 
       - name: Install pip tools.
         run: |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,65 +32,73 @@ jenkins_pv_debug: false
 # Plugins and their versions that must be present on p!v jenkins instances
 jenkins_pv_plugins_present:
   - name: active-directory
-    version: "2.24"
+    version: "2.25.1"
   - name: aws-credentials
-    version: "1.29"
+    version: "1.33"
   - name: aws-java-sdk
-    version: "1.11.995"
+    version: "1.12.131-302.vbef9650c6521"
+  - name: aws-java-sdk-logs
+  - name: aws-java-sdk-ec2
+  - name: aws-java-sdk-elasticbeanstalk
+  - name: aws-java-sdk-ssm
+  - name: aws-java-sdk-codebuild
+  - name: aws-java-sdk-minimal
+  - name: aws-java-sdk-cloudformation
+  - name: aws-java-sdk-ecs
+  - name: aws-java-sdk-iam
+  - name: aws-java-sdk-ecr
   - name: ansible
     version: "1.1"
   - name: ant
-    version: "1.11"
+    version: "1.13"
   - name: artifactdeployer
     version: "1.2"
   - name: badge
-    version: "1.8"
+    version: "1.9.1"
   - name: blueocean-autofavorite
     version: "1.2.4"
   - name: blueocean-bitbucket-pipeline
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-commons
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-config
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-core-js
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-dashboard
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-display-url
     version: "2.4.1"
   - name: blueocean-events
-    version: "1.24.7"
-  - name: blueocean-executor-info
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-git-pipeline
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-github-pipeline
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-i18n
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-jira
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-jwt
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-rest-impl
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-personalization
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-pipeline-api-impl
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-pipeline-editor
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-pipeline-scm-api
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-rest
-    version: "1.24.7"
+    version: "1.25.2"
   - name: blueocean-web
-    version: "1.24.7"
+    version: "1.25.2"
   - name: build-blocker-plugin
-    version: "1.7.7"
+    version: "1.7.8"
   - name: build-monitor-plugin
-    version: "1.12+build.201809061734"
+    version: "1.13+build.202201221819"
   - name: build-name-setter
     version: "2.2.0"
   - name: build-pipeline-plugin
@@ -104,53 +112,51 @@ jenkins_pv_plugins_present:
   - name: clone-workspace-scm
     version: "0.6"
   - name: cloudbees-bitbucket-branch-source
-    version: "2.9.9"
+    version: "751.vda_24678a_f781"
   - name: copyartifact
-    version: "1.46.1"
+    version: "1.46.2"
   - name: conditional-buildstep
     version: "1.4.1"
   - name: configurationslicing
     version: "1.52"
-  - name: copy-to-slave
-    version: "1.4.4"
   - name: cvs
     version: "2.19"
   - name: delivery-pipeline-plugin
     version: "1.4.2"
   - name: dependency-check-jenkins-plugin
-    version: "5.1.1"
+    version: "5.1.2"
   - name: dependency-track
-    version: "3.1.1"
+    version: "4.0.0"
   - name: disk-usage
     version: "0.28"
   - name: dtkit-api
     version: "3.0.0"
   - name: envinject-api
-    version: "1.7"
+    version: "1.8"
   - name: envinject
     version: "2.4.0"
   - name: extensible-choice-parameter
-    version: "1.7.0"
+    version: "1.8.0"
   - name: extended-read-permission
     version: "3.2"
   - name: extra-columns
-    version: "1.23"
+    version: "1.25"
   - name: favorite
     version: "2.3.3"
   - name: gatling
     version: "1.3.0"
   - name: git-parameter
-    version: "0.9.13"
+    version: "0.9.15"
   - name: github
-    version: "1.33.1"
+    version: "1.34.1"
   - name: github-api
-    version: "1.123"
+    version: "1.301-378.v9807bd746da5"
   - name: github-branch-source
-    version: "2.11.1"
+    version: "2.11.4"
   - name: gitlab-api
     version: "1.0.6"
   - name: gitlab-branch-source
-    version: "1.5.7"
+    version: "1.5.9"
   - name: greenballs
     version: "1.15.1"
   - name: groovy
@@ -162,33 +168,33 @@ jenkins_pv_plugins_present:
   - name: handy-uri-templates-2-api
     version: "2.1.8-1.0"
   - name: htmlpublisher
-    version: "1.25"
-  - name: icon-shim
-    version: "3.0.0"
+    version: "1.28"
   - name: instant-messaging
-    version: "1.42"
+    version: "1.48"
+  - name: jaxb
+    version: "2.3.0.1"
   - name: jenkins-design-language
-    version: "1.24.7"
+    version: "1.25.2"
   - name: jira
-    version: "3.3"
+    version: "3.6"
   - name: jjwt-api
     version: "0.11.2-9.c8b45b8bb173"
+  - name: jnr-posix-api
+    version: "3.1.7-1"
   - name: jobConfigHistory
-    version: "2.27"
+    version: "2.31-rc1098.b666422863b2"
   - name: job-import-plugin
     version: "3.4"
   - name: job-restrictions
     version: "0.8"
-  - name: jquery-ui
-    version: "1.0.2"
   - name: ldap
     version: "2.7"
   - name: locale
     version: "1.4"
   - name: lockable-resources
-    version: "2.11"
+    version: "2.13"
   - name: log-parser
-    version: "2.1"
+    version: "2.2"
   - name: m2release
     version: "0.16.2"
   - name: mapdb-api
@@ -200,47 +206,44 @@ jenkins_pv_plugins_present:
   - name: matrix-auth
     version: "2.6.7"
   - name: mercurial
-    version: "2.15"
+    version: "2.16"
   - name: msbuild
     version: "1.30"
+  # needs to be enabled due to legacy projects
   - name: multiple-scms
     version: "0.8"
   - name: nvm-wrapper
     version: "0.1.7"
   - name: okhttp-api
-    version: "3.14.9"
+    version: "4.9.3-105.vb96869f8ac3a"
   - name: pam-auth
-    version: "1.6"
+    version: "1.7"
   - name: parameter-separator
     version: "1.3"
   - name: parameterized-trigger
-    version: "2.40"
+    version: "2.43"
   - name: Parameterized-Remote-Trigger
     version: "3.1.5.1"
   - name: performance
-    version: "3.19"
+    version: "3.20"
   - name: pipeline-npm
     version: "0.9.2"
   - name: plugin-usage-plugin
-    version: "1.2"
+    version: "2.1"
   - name: publish-over
     version: "0.22"
   - name: publish-over-cifs
     version: "0.16"
-  - name: publish-over-ssh
-    version: "1.22"
   - name: pubsub-light
-    version: "1.14"
+    version: "1.16"
   - name: resource-disposer
-    version: "0.15"
+    version: "0.17"
   - name: role-strategy
-    version: "3.1.1"
-  - name: ruby-runtime
-    version: "0.12"
+    version: "3.2.0"
   - name: run-condition
     version: "1.5"
   - name: shelve-project-plugin
-    version: "3.1"
+    version: "3.2"
   - name: shiningpanda
     version: "0.24"
   - name: skip-notifications-trait
@@ -248,25 +251,25 @@ jenkins_pv_plugins_present:
   - name: slave-setup
     version: "1.10"
   - name: sse-gateway
-    version: "1.24"
+    version: "1.25"
   - name: sonar
-    version: "2.13.1"
+    version: "2.14"
   - name: ssh
     version: "2.6.1"
   - name: ssh-agent
-    version: "1.22"
+    version: "1.24.1"
   - name: strict-crumb-issuer
     version: "2.1.0"
   - name: subversion
-    version: "2.14.2"
+    version: "2.15.2"
   - name: testng-plugin
-    version: "1.15"
+    version: "554.va4a552116332"
   - name: test-results-analyzer
     version: "0.3.5"
   - name: text-finder
-    version: "1.16"
+    version: "1.18"
   - name: throttle-concurrents
-    version: "2.2"
+    version: "2.6"
   - name: translation
     version: "1.16"
   - name: URLSCM
@@ -275,22 +278,28 @@ jenkins_pv_plugins_present:
     version: "1.4"
   - name: view-job-filters
     version: "2.3"
-  - name: violations
-    version: "0.7.11"
-  - name: warnings
-    version: "5.0.2"
   - name: windows-slaves
     version: "1.8"
   - name: workflow-aggregator
     version: "2.6"
   - name: ws-cleanup
-    version: "0.39"
+    version: "0.40"
   - name: xunit
-    version: "3.0.2"
+    version: "3.0.5"
 
 # Plugins that must be absent on p!v jenkins instances
 jenkins_pv_plugins_absent:
+  - name: blueocean-executor-info
+  - name: copy-to-slave
   - name: file-leak-detector
-  - name: monitoring
+  - name: icon-shim
   - name: jabber
+  - name: jquery-ui
+  - name: multi-branch-project-plugin
+  - name: monitoring
+  - name: persona
   - name: pipeline-maven
+  - name: publish-over-ssh
+  - name: ruby-runtime
+  - name: violations
+  - name: warnings

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -290,6 +290,7 @@ jenkins_pv_plugins_present:
 # Plugins that must be absent on p!v jenkins instances
 jenkins_pv_plugins_absent:
   - name: blueocean-executor-info
+  - name: ci-game
   - name: copy-to-slave
   - name: file-leak-detector
   - name: icon-shim

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,15 +38,25 @@ jenkins_pv_plugins_present:
   - name: aws-java-sdk
     version: "1.12.131-302.vbef9650c6521"
   - name: aws-java-sdk-logs
+    version: "1.12.131-302.vbef9650c6521"
   - name: aws-java-sdk-ec2
+    version: "1.12.131-302.vbef9650c6521"
   - name: aws-java-sdk-elasticbeanstalk
+    version: "1.12.131-302.vbef9650c6521"
   - name: aws-java-sdk-ssm
+    version: "1.12.131-302.vbef9650c6521"
   - name: aws-java-sdk-codebuild
+    version: "1.12.131-302.vbef9650c6521"
   - name: aws-java-sdk-minimal
+    version: "1.12.131-302.vbef9650c6521"
   - name: aws-java-sdk-cloudformation
+    version: "1.12.131-302.vbef9650c6521"
   - name: aws-java-sdk-ecs
+    version: "1.12.131-302.vbef9650c6521"
   - name: aws-java-sdk-iam
+    version: "1.12.131-302.vbef9650c6521"
   - name: aws-java-sdk-ecr
+    version: "1.12.131-302.vbef9650c6521"
   - name: ansible
     version: "1.1"
   - name: ant

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,25 +37,25 @@ jenkins_pv_plugins_present:
     version: "1.33"
   - name: aws-java-sdk
     version: "1.12.131-302.vbef9650c6521"
-  - name: aws-java-sdk-logs
-    version: "1.12.131-302.vbef9650c6521"
   - name: aws-java-sdk-ec2
-    version: "1.12.131-302.vbef9650c6521"
-  - name: aws-java-sdk-elasticbeanstalk
-    version: "1.12.131-302.vbef9650c6521"
-  - name: aws-java-sdk-ssm
-    version: "1.12.131-302.vbef9650c6521"
-  - name: aws-java-sdk-codebuild
-    version: "1.12.131-302.vbef9650c6521"
-  - name: aws-java-sdk-minimal
-    version: "1.12.131-302.vbef9650c6521"
-  - name: aws-java-sdk-cloudformation
     version: "1.12.131-302.vbef9650c6521"
   - name: aws-java-sdk-ecs
     version: "1.12.131-302.vbef9650c6521"
+  - name: aws-java-sdk-ecr
+    version: "1.12.131-302.vbef9650c6521"
+  - name: aws-java-sdk-elasticbeanstalk
+    version: "1.12.131-302.vbef9650c6521"
   - name: aws-java-sdk-iam
     version: "1.12.131-302.vbef9650c6521"
-  - name: aws-java-sdk-ecr
+  - name: aws-java-sdk-cloudformation
+    version: "1.12.131-302.vbef9650c6521"
+  - name: aws-java-sdk-codebuild
+    version: "1.12.131-302.vbef9650c6521"
+  - name: aws-java-sdk-logs
+    version: "1.12.131-302.vbef9650c6521"
+  - name: aws-java-sdk-minimal
+    version: "1.12.131-302.vbef9650c6521"
+  - name: aws-java-sdk-ssm
     version: "1.12.131-302.vbef9650c6521"
   - name: ansible
     version: "1.1"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,29 +34,29 @@ jenkins_pv_plugins_present:
   - name: active-directory
     version: "2.25.1"
   - name: aws-credentials
-    version: "1.33"
+    version: "189.v3551d5642995"
   - name: aws-java-sdk
-    version: "1.12.131-302.vbef9650c6521"
+    version: "1.12.163-315.v2b_716ec8e4df"
   - name: aws-java-sdk-ec2
-    version: "1.12.131-302.vbef9650c6521"
+    version: "1.12.163-315.v2b_716ec8e4df"
   - name: aws-java-sdk-ecs
-    version: "1.12.131-302.vbef9650c6521"
+    version: "1.12.163-315.v2b_716ec8e4df"
   - name: aws-java-sdk-ecr
-    version: "1.12.131-302.vbef9650c6521"
+    version: "1.12.163-315.v2b_716ec8e4df"
   - name: aws-java-sdk-elasticbeanstalk
-    version: "1.12.131-302.vbef9650c6521"
+    version: "1.12.163-315.v2b_716ec8e4df"
   - name: aws-java-sdk-iam
-    version: "1.12.131-302.vbef9650c6521"
+    version: "1.12.163-315.v2b_716ec8e4df"
   - name: aws-java-sdk-cloudformation
-    version: "1.12.131-302.vbef9650c6521"
+    version: "1.12.163-315.v2b_716ec8e4df"
   - name: aws-java-sdk-codebuild
-    version: "1.12.131-302.vbef9650c6521"
+    version: "1.12.163-315.v2b_716ec8e4df"
   - name: aws-java-sdk-logs
-    version: "1.12.131-302.vbef9650c6521"
+    version: "1.12.163-315.v2b_716ec8e4df"
   - name: aws-java-sdk-minimal
-    version: "1.12.131-302.vbef9650c6521"
+    version: "1.12.163-315.v2b_716ec8e4df"
   - name: aws-java-sdk-ssm
-    version: "1.12.131-302.vbef9650c6521"
+    version: "1.12.163-315.v2b_716ec8e4df"
   - name: ansible
     version: "1.1"
   - name: ant
@@ -66,49 +66,49 @@ jenkins_pv_plugins_present:
   - name: badge
     version: "1.9.1"
   - name: blueocean-autofavorite
-    version: "1.2.4"
+    version: "1.2.5"
   - name: blueocean-bitbucket-pipeline
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-commons
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-config
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-core-js
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-dashboard
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-display-url
     version: "2.4.1"
   - name: blueocean-events
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-git-pipeline
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-github-pipeline
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-i18n
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-jira
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-jwt
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-rest-impl
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-personalization
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-pipeline-api-impl
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-pipeline-editor
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-pipeline-scm-api
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-rest
-    version: "1.25.2"
+    version: "1.25.3"
   - name: blueocean-web
-    version: "1.25.2"
+    version: "1.25.3"
   - name: build-blocker-plugin
     version: "1.7.8"
   - name: build-monitor-plugin
-    version: "1.13+build.202201221819"
+    version: "1.13+build.202202281553"
   - name: build-name-setter
     version: "2.2.0"
   - name: build-pipeline-plugin
@@ -122,7 +122,7 @@ jenkins_pv_plugins_present:
   - name: clone-workspace-scm
     version: "0.6"
   - name: cloudbees-bitbucket-branch-source
-    version: "751.vda_24678a_f781"
+    version: "757.vddedc5f2589a_"
   - name: copyartifact
     version: "1.46.2"
   - name: conditional-buildstep
@@ -136,15 +136,15 @@ jenkins_pv_plugins_present:
   - name: dependency-check-jenkins-plugin
     version: "5.1.2"
   - name: dependency-track
-    version: "4.0.0"
+    version: "4.1.0"
   - name: disk-usage
     version: "0.28"
   - name: dtkit-api
     version: "3.0.0"
   - name: envinject-api
-    version: "1.8"
+    version: "1.180.v98d833b_27470"
   - name: envinject
-    version: "2.4.0"
+    version: "2.839.v52c702c10635"
   - name: extensible-choice-parameter
     version: "1.8.0"
   - name: extended-read-permission
@@ -152,13 +152,13 @@ jenkins_pv_plugins_present:
   - name: extra-columns
     version: "1.25"
   - name: favorite
-    version: "2.3.3"
+    version: "2.4.0"
   - name: gatling
     version: "1.3.0"
   - name: git-parameter
     version: "0.9.15"
   - name: github
-    version: "1.34.1"
+    version: "1.34.2"
   - name: github-api
     version: "1.301-378.v9807bd746da5"
   - name: github-branch-source
@@ -178,31 +178,31 @@ jenkins_pv_plugins_present:
   - name: handy-uri-templates-2-api
     version: "2.1.8-1.0"
   - name: htmlpublisher
-    version: "1.28"
+    version: "1.29"
   - name: instant-messaging
     version: "1.48"
   - name: jaxb
     version: "2.3.0.1"
   - name: jenkins-design-language
-    version: "1.25.2"
+    version: "1.25.3"
   - name: jira
-    version: "3.6"
+    version: "3.7"
   - name: jjwt-api
     version: "0.11.2-9.c8b45b8bb173"
   - name: jnr-posix-api
-    version: "3.1.7-1"
+    version: "3.1.7-2"
   - name: jobConfigHistory
-    version: "2.31-rc1098.b666422863b2"
+    version: "1119.v509e1017356b_"
   - name: job-import-plugin
     version: "3.4"
   - name: job-restrictions
     version: "0.8"
   - name: ldap
-    version: "2.7"
+    version: "2.8"
   - name: locale
-    version: "1.4"
+    version: "144.v1a_998824ddb_3"
   - name: lockable-resources
-    version: "2.13"
+    version: "2.14"
   - name: log-parser
     version: "2.2"
   - name: m2release


### PR DESCRIPTION
Add/Update plugins for Jenkins 2.319.2

**Removed deprecated plugins:**

* blueocean-executor-info
* ci-game
* copy-to-slave
* jquery-ui
* multi-branch-project-plugin
* persona
* publish-over-ssh
* violations